### PR TITLE
fix: throw if initialized multiple times

### DIFF
--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -3,6 +3,8 @@ import { isProductionEnv } from '../utils/env'
 
 import { CustomTransport, OriginApplication } from './CustomTransport'
 
+let isInitialized = false
+
 /**
  * Initializes Amplitude with API key for project.
  *
@@ -18,6 +20,11 @@ export function initializeAnalytics(
   originApplication: OriginApplication,
   proxyUrl: string | undefined
 ) {
+  if (isInitialized) {
+    throw new Error('initializeAnalytics called multiple times - is it inside of a React component?')
+  }
+  isInitialized = true
+
   init(
     apiKey,
     /* userId= */ undefined, // User ID should be undefined to let Amplitude default to Device ID


### PR DESCRIPTION
Prevents downstream usage from calling `initializeAnalytics` multiple times, which adds unnecessary network requests to startup.
See https://github.com/Uniswap/interface/pull/5173 as an example of how `initializeAnalytics` was called multiple times.