### PR TITLE
feat: add debug option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ which in turn uses the [Angular commit message suggestions](https://github.com/a
 
 ## Documentation
 
+### Initializing Analytics
+
 The client should be initialized before it is used. To initialize the client, pass in the API key of the application, as well as the name of
 the application. If the application name is not listed under `OriginApplication`, it should be added under the enum. An additional
 configuration object can be passed.
@@ -64,6 +66,18 @@ initializeAnalytics(MY_API_KEY, OriginApplication.INTERFACE, {
 ```
 Note that an `Error` is thrown if the client is initialized more than once.
 
+#### Configuration Options
+
+| Option             | Type    | Description                                                                                  |
+| :--------------    | :------ | :------------------------------------------------------------------------------------------- |
+| `proxyUrl`         | string  | The Amplitude URL to send events to.                                                         |
+| `defaultEventName` | string  | When an event name is not provided, use the provided default. Defaults to `Page Viewed`.     |
+| `commitHash`       | string  | The git commit hash to send with Trace events only. Does not send by default on raw events.  |
+| `isProductionEnv`  | boolean | When not set to true, user properties are not set on the Amplitude client.                   |
+| `debug`            | boolean | When enabled, logs events to the console. Cannot be enabled while `isProductionEnv` is true. |
+
+### Logging Events Directly
+
 Before logging an event, make sure to add it under the `EventName` enum in the [@uniswap/analytics-events](https://www.npmjs.com/package/@uniswap/analytics-events) package. To log an analytics event:
 ```js
 import { sendAnalyticsEvent } from '@uniswap/analytics'
@@ -73,6 +87,8 @@ sendAnalyticsEvent(EventName.PAGE_CLICKED, {
     elementName: ElementName.TOP_MENU
 })
 ```
+
+### Using the Trace Component
 
 There is also a built in React component that logs an event when it is first mounted. You may use it as a wrapper:
 ```js

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ initializeAnalytics(MY_API_KEY, OriginApplication.INTERFACE, {
     proxyUrl: MY_PROXY_URL
 })
 ```
-Note that an `Error` is thrown if the client is initialized more than once.
+Note that an `Error` is thrown if the client is initialized more than once or if an invalid configuration object is provided.
 
 #### Configuration Options
 

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -4,10 +4,10 @@ import { ApplicationTransport, OriginApplication } from './ApplicationTransport'
 
 type AnalyticsConfig = {
   proxyUrl?: string
-  // If false or undefined, does not set user properties on the Amplitude client
-  isProductionEnv?: boolean
   commitHash?: string
   defaultEventName?: string
+  // If false or undefined, does not set user properties on the Amplitude client
+  isProductionEnv?: boolean
   // When enabled, console log events before sending to amplitude
   debug?: boolean
 }
@@ -29,6 +29,11 @@ export function initializeAnalytics(apiKey: string, originApplication: OriginApp
   if (isInitialized) {
     throw new Error('initializeAnalytics called multiple times - is it inside of a React component?')
   }
+
+  if (config?.debug && config.isProductionEnv) {
+    throw new Error(`It looks like you're trying to initialize analytics in debug mode for production. Please disable debug mode or the production environment`)
+  }
+
   isInitialized = true
   analyticsConfig = config
 

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -8,6 +8,8 @@ type AnalyticsConfig = {
   isProductionEnv?: boolean
   commitHash?: string
   defaultEventName?: string
+  // When enabled, console log events before sending to amplitude
+  debug?: boolean
 }
 
 let isInitialized = false
@@ -54,6 +56,13 @@ export function initializeAnalytics(apiKey: string, originApplication: OriginApp
 /** Sends an event to Amplitude. */
 export function sendAnalyticsEvent(eventName: string, eventProperties?: Record<string, unknown>) {
   const origin = window.location.origin
+
+  if (analyticsConfig?.debug) {
+    console.log({
+      eventName,
+      eventProperties: { ...eventProperties, origin }
+    });
+  }
 
   track(eventName, { ...eventProperties, origin })
 }

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -31,7 +31,9 @@ export function initializeAnalytics(apiKey: string, originApplication: OriginApp
   }
 
   if (config?.debug && config.isProductionEnv) {
-    throw new Error(`It looks like you're trying to initialize analytics in debug mode for production. Please disable debug mode or the production environment`)
+    throw new Error(
+      `It looks like you're trying to initialize analytics in debug mode for production. Please disable debug mode or the production environment`
+    )
   }
 
   isInitialized = true
@@ -65,8 +67,8 @@ export function sendAnalyticsEvent(eventName: string, eventProperties?: Record<s
   if (analyticsConfig?.debug) {
     console.log({
       eventName,
-      eventProperties: { ...eventProperties, origin }
-    });
+      eventProperties: { ...eventProperties, origin },
+    })
   }
 
   track(eventName, { ...eventProperties, origin })


### PR DESCRIPTION
- Adds a `debug` boolean option to the analytics config, ensuring it can't be turned on in production
- Adds documentation for all config options to the README