### PR TITLE
fix: type the event name to prevent unknown events

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,13 @@ Note that an `Error` is thrown if the client is initialized more than once or if
 
 #### Configuration Options
 
-| Option             | Type    | Description                                                                                  |
-| :--------------    | :------ | :------------------------------------------------------------------------------------------- |
-| `proxyUrl`         | string  | The Amplitude URL to send events to.                                                         |
-| `defaultEventName` | string  | When an event name is not provided, use the provided default. Defaults to `Page Viewed`.     |
-| `commitHash`       | string  | The git commit hash to send with Trace events only. Does not send by default on raw events.  |
-| `isProductionEnv`  | boolean | When not set to true, user properties are not set on the Amplitude client.                   |
-| `debug`            | boolean | When enabled, logs events to the console. Cannot be enabled while `isProductionEnv` is true. |
+| Option             | Type       | Description                                                                                  |
+| :--------------    | :--------- | :------------------------------------------------------------------------------------------- |
+| `proxyUrl`         | string     | The Amplitude URL to send events to.                                                         |
+| `defaultEventName` | EventName  | When an event name is not provided, use the provided default. Defaults to `Page Viewed`.     |
+| `commitHash`       | string     | The git commit hash to send with Trace events only. Does not send by default on raw events.  |
+| `isProductionEnv`  | boolean    | When not set to true, user properties are not set on the Amplitude client.                   |
+| `debug`            | boolean    | When enabled, logs events to the console. Cannot be enabled while `isProductionEnv` is true. |
 
 ### Logging Events Directly
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/react-dom": "^18.0.8",
     "@typescript-eslint/eslint-plugin": "^4",
     "@typescript-eslint/parser": "^4",
+    "@uniswap/analytics-events": ">=1",
     "babel-jest": "^29.2.2",
     "eslint": "^7.11.0",
     "eslint-config-prettier": "^6.11.0",
@@ -70,6 +71,6 @@
     "react-dom": "^18.2.0"
   },
   "peerDependencies": {
-    "@uniswap/analytics-events": "^1.6.0"
+    "@uniswap/analytics-events": ">=1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
     "@amplitude/analytics-browser": "^1.5.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
+  },
+  "peerDependencies": {
+    "@uniswap/analytics-events": "^1.6.0"
   }
 }

--- a/src/analytics/Trace.tsx
+++ b/src/analytics/Trace.tsx
@@ -1,8 +1,9 @@
+import { EventName } from '@uniswap/analytics-events'
 import React, { createContext, memo, PropsWithChildren, useContext, useEffect, useMemo } from 'react'
 
 import { sendAnalyticsEvent, analyticsConfig } from '.'
 
-const DEFAULT_EVENT = 'Page Viewed'
+const DEFAULT_EVENT = EventName.PAGE_VIEWED
 
 export interface ITraceContext {
   // Highest order context: eg Swap or Explore.
@@ -28,7 +29,7 @@ export function useTrace(trace?: ITraceContext): ITraceContext {
 
 type TraceProps = {
   shouldLogImpression?: boolean // whether to log impression on mount
-  name?: string
+  name?: EventName
   properties?: Record<string, unknown>
 } & ITraceContext
 

--- a/src/analytics/TraceEvent.tsx
+++ b/src/analytics/TraceEvent.tsx
@@ -1,3 +1,4 @@
+import type { EventName } from '@uniswap/analytics-events'
 import React, { Children, cloneElement, isValidElement, memo, PropsWithChildren, SyntheticEvent } from 'react'
 
 import { sendAnalyticsEvent } from '.'
@@ -5,7 +6,7 @@ import { ITraceContext, Trace, TraceContext } from './Trace'
 
 type TraceEventProps = {
   events: string[]
-  name: string
+  name: EventName
   properties?: Record<string, unknown>
   shouldLogImpression?: boolean
 } & ITraceContext
@@ -52,7 +53,7 @@ function getEventHandlers(
   child: React.ReactElement,
   traceContext: ITraceContext,
   events: string[],
-  name: string,
+  name: EventName,
   properties?: Record<string, unknown>,
   shouldLogImpression = true
 ) {

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -1,11 +1,12 @@
 import { Identify, identify, init, track } from '@amplitude/analytics-browser'
+import type { EventName } from '@uniswap/analytics-events'
 
 import { ApplicationTransport, OriginApplication } from './ApplicationTransport'
 
 type AnalyticsConfig = {
   proxyUrl?: string
   commitHash?: string
-  defaultEventName?: string
+  defaultEventName?: EventName
   // If false or undefined, does not set user properties on the Amplitude client
   isProductionEnv?: boolean
   // When enabled, console log events before sending to amplitude
@@ -61,7 +62,7 @@ export function initializeAnalytics(apiKey: string, originApplication: OriginApp
 }
 
 /** Sends an event to Amplitude. */
-export function sendAnalyticsEvent(eventName: string, eventProperties?: Record<string, unknown>) {
+export function sendAnalyticsEvent(eventName: EventName, eventProperties?: Record<string, unknown>) {
   const origin = window.location.origin
 
   if (analyticsConfig?.debug) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1992,6 +1992,11 @@
     "@typescript-eslint/types" "5.42.0"
     eslint-visitor-keys "^3.3.0"
 
+"@uniswap/analytics-events@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/analytics-events/-/analytics-events-1.6.0.tgz#378d08f803170ca408f0c39b446cc025f3acbc37"
+  integrity sha512-z04okZb0J0dyAm/zie7JSJcPCTjsPYCDLCSfSjsG15mXnub0Q/iWTSiVI4lDiNj0/SUiMVIEQiINPuXSnS9k5w==
+
 JSONStream@^1.0.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1992,10 +1992,10 @@
     "@typescript-eslint/types" "5.42.0"
     eslint-visitor-keys "^3.3.0"
 
-"@uniswap/analytics-events@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@uniswap/analytics-events/-/analytics-events-1.6.0.tgz#378d08f803170ca408f0c39b446cc025f3acbc37"
-  integrity sha512-z04okZb0J0dyAm/zie7JSJcPCTjsPYCDLCSfSjsG15mXnub0Q/iWTSiVI4lDiNj0/SUiMVIEQiINPuXSnS9k5w==
+"@uniswap/analytics-events@>=1":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/analytics-events/-/analytics-events-2.5.0.tgz#0956231afede2ed04f051d0f54c11ac34ea7df25"
+  integrity sha512-DFI3awVgVaO/gthl9lQ3jfJu/lmAfJCXeuUcfzGURFyr3NjOxpdkDq68OMGKmKvTceofx3V1qCMG0lrXuDGCog==
 
 JSONStream@^1.0.4:
   version "1.3.5"


### PR DESCRIPTION
## Background

Events are defined in https://github.com/Uniswap/analytics-events, but typed as `string`, which leads to looser usage. For example, https://github.com/Uniswap/interface/pull/5748 introduces new events as strings, but defers their codified definition.

This change intends to add a speedbump, so that undefined events can still be used, but must be explicitly cast in order to get through the typechecker (eg `sendAnalyticsEvent('Undocumented Event Name' as EventName)`), which should encourage safer usage and - hopefully - faster definition of these events.

## Changes

- Types the eventName. This prevents unknown events from being added without first being vetted through analytics-events.

## Testing

- Typing-only change; no tests added or modified
