### PR TITLE
feat: expose function to access amplitude device id

### DIFF
--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -1,4 +1,12 @@
-import { Identify, identify, init, track } from '@amplitude/analytics-browser'
+import {
+  Identify,
+  identify,
+  init,
+  track,
+  getDeviceId as getAmplitudeDeviceId,
+  getUserId as getAmplitudeUserId,
+  getSessionId as getAmplitudeSessionId,
+} from '@amplitude/analytics-browser'
 
 import { ApplicationTransport, OriginApplication } from './ApplicationTransport'
 
@@ -72,6 +80,18 @@ export function sendAnalyticsEvent(eventName: string, eventProperties?: Record<s
   }
 
   track(eventName, { ...eventProperties, origin })
+}
+
+export function getDeviceId() {
+  return getAmplitudeDeviceId()
+}
+
+export function getUserId() {
+  return getAmplitudeUserId()
+}
+
+export function getSessionId() {
+  return getAmplitudeSessionId()
 }
 
 type UserValue = string | number | boolean | string[] | number[]

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,11 @@
 export * from './analytics/Trace.js'
 export * from './analytics/TraceEvent.js'
-export { initializeAnalytics, sendAnalyticsEvent, user } from './analytics/index.js'
+export {
+  initializeAnalytics,
+  sendAnalyticsEvent,
+  getDeviceId,
+  getSessionId,
+  getUserId,
+  user,
+} from './analytics/index.js'
 export { OriginApplication } from './analytics/ApplicationTransport.js'


### PR DESCRIPTION
Exposes amplitude user/device/session IDs in the package interface.

## Background
This is needed to initialize a different logging library, so we can join the datasets between the two by linking with these IDs.
...

## Changes
adds new functions to the package surface to call into the Amplitude SDK - user, session, and device ID getters.
- 

## Testing

installed a local version of the package into `interface` and verified that the functions are available, and that they are returning values as expected (for device ID)
