### PR TITLE
fix: ignore subsequent inits from hot-loading

### DIFF
--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -50,7 +50,6 @@ export function initializeAnalytics(apiKey: string, originApplication: OriginApp
       )
     }
   }
-  }
 
   isInitialized = true
   analyticsConfig = config

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -34,14 +34,18 @@ export let analyticsConfig: AnalyticsConfig | undefined
  * @param options Contains options to be used in the configuration of the package
  */
 export function initializeAnalytics(apiKey: string, originApplication: OriginApplication, config?: AnalyticsConfig) {
-  if (isInitialized) {
-    throw new Error('initializeAnalytics called multiple times - is it inside of a React component?')
-  }
-
-  if (config?.debug && config.isProductionEnv) {
-    throw new Error(
-      `It looks like you're trying to initialize analytics in debug mode for production. Please disable debug mode or the production environment`
-    )
+  if (config?.isProductionEnv) {
+    if (isInitialized) {
+      throw new Error('initializeAnalytics called multiple times. Ensure it is outside of a React component.')
+    } else {
+      // Non-production environments may use hot-reloading, which will re-initialize but should be ignored.
+      return
+    }
+    if (config.debug) {
+      throw new Error(
+        `It looks like you're trying to initialize analytics in debug mode for production. Disable debug mode or use a non-production environment.`
+      )
+    }
   }
 
   isInitialized = true

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -34,18 +34,22 @@ export let analyticsConfig: AnalyticsConfig | undefined
  * @param options Contains options to be used in the configuration of the package
  */
 export function initializeAnalytics(apiKey: string, originApplication: OriginApplication, config?: AnalyticsConfig) {
+  // Non-production environments may use hot-reloading, which will re-initialize but should be ignored.
+  if (!config?.isProductionEnv && isInitialized) {
+      return
+  }
+
   if (config?.isProductionEnv) {
     if (isInitialized) {
       throw new Error('initializeAnalytics called multiple times. Ensure it is outside of a React component.')
-    } else {
-      // Non-production environments may use hot-reloading, which will re-initialize but should be ignored.
-      return
     }
+    
     if (config.debug) {
       throw new Error(
         `It looks like you're trying to initialize analytics in debug mode for production. Disable debug mode or use a non-production environment.`
       )
     }
+  }
   }
 
   isInitialized = true

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -36,14 +36,14 @@ export let analyticsConfig: AnalyticsConfig | undefined
 export function initializeAnalytics(apiKey: string, originApplication: OriginApplication, config?: AnalyticsConfig) {
   // Non-production environments may use hot-reloading, which will re-initialize but should be ignored.
   if (!config?.isProductionEnv && isInitialized) {
-      return
+    return
   }
 
   if (config?.isProductionEnv) {
     if (isInitialized) {
       throw new Error('initializeAnalytics called multiple times. Ensure it is outside of a React component.')
     }
-    
+
     if (config.debug) {
       throw new Error(
         `It looks like you're trying to initialize analytics in debug mode for production. Disable debug mode or use a non-production environment.`


### PR DESCRIPTION
Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) and start with a valid [type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

## Background

github.com/Uniswap/interface uses hot-reloading for non-production builds (run with `yarn start`), which will re-initialize analytics every time a file is changed.

## Changes

- Ignores subsequent initializations as a result of hot-loading, if the environment is non-production.
- Continues to throw an error for subsequent initializations for production environments.