### PR TITLE
feat: log impression on `shouldLogImpression` change

### DIFF
--- a/src/analytics/Trace.tsx
+++ b/src/analytics/Trace.tsx
@@ -33,7 +33,7 @@ type TraceProps = {
 } & ITraceContext
 
 /**
- * Sends an analytics event if shouldLogImpression is set to  true,
+ * Sends an analytics event on mount or if `shouldLogImpression` toggles,
  * and propagates the context to child traces.
  *
  * It defaults to logging an EventName.PAGE_VIEWED if no `name` is provided.
@@ -68,6 +68,8 @@ export const Trace = memo(
           git_commit_hash: analyticsConfig?.commitHash,
         })
       }
+      // Impressions should only be logged on mount or if `shouldLogImpression` toggles
+      // (ie if the component becomes "viewed"), but not if/when other deps update.
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [shouldLogImpression])
 

--- a/src/analytics/Trace.tsx
+++ b/src/analytics/Trace.tsx
@@ -68,9 +68,8 @@ export const Trace = memo(
           git_commit_hash: analyticsConfig?.commitHash,
         })
       }
-      // Impressions should only be logged on mount.
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
+    }, [shouldLogImpression])
 
     return <TraceContext.Provider value={combinedProps}>{children}</TraceContext.Provider>
   }

--- a/src/analytics/Trace.tsx
+++ b/src/analytics/Trace.tsx
@@ -33,7 +33,7 @@ type TraceProps = {
 } & ITraceContext
 
 /**
- * Sends an analytics event on mount (if shouldLogImpression is set),
+ * Sends an analytics event if shouldLogImpression is set to  true,
  * and propagates the context to child traces.
  *
  * It defaults to logging an EventName.PAGE_VIEWED if no `name` is provided.


### PR DESCRIPTION
- We're running into a problem with the `Trace` event that makes it not work with opt-in impressions
- We're passing in `shouldLogImpression` when the opt-in components get rendered, and the way the Trace component is set up, the event never gets fired if the initial value of shouldLogImpression is false
- We always render `Trace` despite it being visible or not because of the way we do our animations
