### PR TITLE
chore: add mobile origin

### DIFF
--- a/src/analytics/ApplicationTransport.ts
+++ b/src/analytics/ApplicationTransport.ts
@@ -4,6 +4,7 @@ import { Payload, Response, Transport } from '@amplitude/analytics-types'
 export enum OriginApplication {
   DOCS = 'docs',
   INTERFACE = 'interface',
+  MOBILE = 'mobile-analytics-uniswap',
   ORG = 'org',
 }
 


### PR DESCRIPTION
## Background

The mobile origin was used on the back end before release, this moves it into the shared analytics code

## Changes

- Adds the mobile application origin


