### PR TITLE
feat: add info as an origin app

### DIFF
--- a/src/analytics/ApplicationTransport.ts
+++ b/src/analytics/ApplicationTransport.ts
@@ -3,6 +3,7 @@ import { Payload, Response, Transport } from '@amplitude/analytics-types'
 
 export enum OriginApplication {
   DOCS = 'docs',
+  INFO = 'info',
   INTERFACE = 'interface',
   MOBILE = 'mobile-analytics-uniswap',
   ORG = 'org',


### PR DESCRIPTION
Your PR title must follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) and start with a valid [type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type).

## Background
[linear ticket](https://linear.app/uniswap/issue/WEB-2833/analytics-info-site-logging)
...

## Changes

just add "info" as an enum value here, to be used in the `v3-info` app
