### PR TITLE
fix: import issues for the esm build

### DIFF
--- a/src/analytics/Trace.tsx
+++ b/src/analytics/Trace.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, memo, PropsWithChildren, useContext, useEffect, useMemo } from 'react'
 
-import { sendAnalyticsEvent, analyticsConfig } from '.'
+import { sendAnalyticsEvent, analyticsConfig } from './index.js'
 
 const DEFAULT_EVENT = 'Page Viewed'
 

--- a/src/analytics/TraceEvent.tsx
+++ b/src/analytics/TraceEvent.tsx
@@ -1,7 +1,7 @@
 import React, { Children, cloneElement, isValidElement, memo, PropsWithChildren, SyntheticEvent } from 'react'
 
-import { sendAnalyticsEvent } from '.'
-import { ITraceContext, Trace, TraceContext } from './Trace'
+import { sendAnalyticsEvent } from './index.js'
+import { ITraceContext, Trace, TraceContext } from './Trace.js'
 
 type TraceEventProps = {
   events: string[]

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -8,7 +8,7 @@ import {
   getSessionId as getAmplitudeSessionId,
 } from '@amplitude/analytics-browser'
 
-import { ApplicationTransport, OriginApplication } from './ApplicationTransport'
+import { ApplicationTransport, OriginApplication } from './ApplicationTransport.js'
 
 type AnalyticsConfig = {
   proxyUrl?: string


### PR DESCRIPTION
Since the esm build of this package is using `moduleResolution: NodeNext` , we should be using file extensions for relative imports. and avoid directory imports (i.e. importing from '.' and expecting the './index.js'

this should fix errors that users of the package see when trying to use the ESM build

verified these fixes by making the same changes in `universe` and the errors were resolved